### PR TITLE
make sure we always send apns-expiration as integer number 

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -184,7 +184,7 @@ describe('APNS', () => {
       'key': 'value',
       'keyAgain': 'valueAgain'
     });
-    expect(notification.expiry).toEqual(expirationTime / 1000);
+    expect(notification.expiry).toEqual(Math.round(expirationTime / 1000));
     expect(notification.collapseId).toEqual(collapseId);
     done();
   });
@@ -208,7 +208,7 @@ describe('APNS', () => {
   
       let notification = APNS._generateNotification(data, { expirationTime: expirationTime, collapseId: collapseId });
   
-      expect(notification.expiry).toEqual(expirationTime / 1000);
+      expect(notification.expiry).toEqual(Math.round(expirationTime / 1000));
       expect(notification.collapseId).toEqual(collapseId);
   
       let stringifiedJSON = notification.compile();
@@ -307,7 +307,7 @@ describe('APNS', () => {
     let calledArgs = provider.send.calls.first().args;
     let notification = calledArgs[0];
     expect(notification.aps.alert).toEqual(data.data.alert);
-    expect(notification.expiry).toEqual(data['expiration_time'] / 1000);
+    expect(notification.expiry).toEqual(Math.round(data['expiration_time'] / 1000));
     expect(notification.collapseId).toEqual(data['collapse_id']);
     let apnDevices = calledArgs[1];
     expect(apnDevices.length).toEqual(4);
@@ -383,7 +383,7 @@ describe('APNS', () => {
     let calledArgs = provider.send.calls.first().args;
     let notification = calledArgs[0];
     expect(notification.aps.alert).toEqual(data.data.alert);
-    expect(notification.expiry).toEqual(data['expiration_time'] / 1000);
+    expect(notification.expiry).toEqual(Math.round(data['expiration_time'] / 1000));
     expect(notification.collapseId).toEqual(data['collapse_id']);
     let apnDevices = calledArgs[1];
     expect(apnDevices.length).toBe(3);
@@ -392,7 +392,7 @@ describe('APNS', () => {
     calledArgs = providerDev.send.calls.first().args;
     notification = calledArgs[0];
     expect(notification.aps.alert).toEqual(data.data.alert);
-    expect(notification.expiry).toEqual(data['expiration_time'] / 1000);
+    expect(notification.expiry).toEqual(Math.round(data['expiration_time'] / 1000));
     expect(notification.collapseId).toEqual(data['collapse_id']);
     apnDevices = calledArgs[1];
     expect(apnDevices.length).toBe(2);

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -209,7 +209,7 @@ export class APNS {
     notification.payload = payload;
 
     notification.topic = headers.topic;
-    notification.expiry = headers.expirationTime / 1000;
+    notification.expiry = Math.round(headers.expirationTime / 1000);
     notification.collapseId = headers.collapseId;
     return notification;
   }


### PR DESCRIPTION
This pull request quickly addresses the issue where ``apns-expiration`` header that gets sent to the Apple Push Notification Service gets wrongly computed into a floating point number thus generating push error 400 BadExpirationDate reported here https://github.com/parse-community/parse-server/issues/4558.

I have tested in production that this fix gets rid of the error and pushes are going through.

I have not tested or reviewed the logic of computing correct push expiration date from push date.