### PR TITLE
Add test case for apns priority

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -156,6 +156,24 @@ describe('APNS', () => {
     done();
   });
 
+  it('sets priority to 10 if not set explicitly', (done) => {
+    let data = {
+      'alert': 'alert',
+      'title': 'title',
+      'badge': 100,
+      'sound': 'test',
+      'content-available': 1,
+      'mutable-content': 1,
+      'category': 'INVITE_CATEGORY',
+      'threadId': 'a-thread-id',
+      'key': 'value',
+      'keyAgain': 'valueAgain'
+    };
+    let notification = APNS._generateNotification(data, { });
+    expect(notification.priority).toEqual(10);
+    done();
+  });
+
   it('can generate APNS notification', (done) => {
     //Mock request data
     let data = {


### PR DESCRIPTION
Should be set to 10 if not defined explicitly.

From Apple docs:

> The priority of the notification. If you omit this header, APNs sets the notification priority to 10.
> Specify 10 to send the notification immediately. A value of 10 is appropriate for notifications that trigger an alert, play a sound, or badge the app’s icon. It's an error to specify this priority for a notification whose payload contains the content-available key.
> Specify 5 to send the notification based on power considerations on the user’s device. Use this priority for notifications whose payload includes the content-available key. Notifications with this priority might be grouped and delivered in bursts to the user’s device. They may also be throttled, and in some cases not delivered.