### PR TITLE
Fixed wrong usage of contentAvailable for iOS push notifications via Firebase

### DIFF
--- a/src/GCM.js
+++ b/src/GCM.js
@@ -70,7 +70,7 @@ GCM.prototype.send = function(data, devices) {
   }, {});
 
   let deviceTokens = Object.keys(devicesMap);
-  
+
   const resolvers = [];
   const promises = deviceTokens.map(() => new Promise(resolve => resolvers.push(resolve)));
   let registrationTokens = deviceTokens;
@@ -132,8 +132,8 @@ function generateGCMPayload(requestData, pushId, timeStamp, expirationTime) {
     push_id: pushId,
     time: new Date(timeStamp).toISOString()
   }
-  const optionalKeys = ['content_available', 'notification'];
-  optionalKeys.forEach((key, index, array) => {
+  const optionalKeys = ['contentAvailable', 'notification'];
+  optionalKeys.forEach((key) => {
     if (requestData.hasOwnProperty(key)) {
       payload[key] = requestData[key];
     }


### PR DESCRIPTION
I noticed that it is not possible to send notifications to iOS devices due to not being able to pass the correct option to node-gcm. I fixed this wrong string. I tested it, it works great. For typescript the types need to be updated I'll also do it as soon as this is merged


This fixes #164 

https://github.com/ToothlessGear/node-gcm