### PR TITLE
feat: add support for APNS `interruption-level` and `target-content-id`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -202,9 +202,9 @@
       }
     },
     "@parse/node-apn": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-5.0.0.tgz",
-      "integrity": "sha512-S6435WR+QLcUqUuLcG4evGpvfA/F+V37fyiupfeRmoWd+ATlwkfPA8oyt8JCq9kostgtXcrGxtuZjOgdlWlm1g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-5.1.0.tgz",
+      "integrity": "sha512-WT3iVwr1Y/Jf4nq4RGNwBdLwm3gTodsb+g3IY98MPSJ7LCNf+R81Nj/nQO5r/twJfN1v5B8cAgfvPGs2rPelvg==",
       "requires": {
         "debug": "4.3.2",
         "jsonwebtoken": "8.5.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "nyc": "14.1.1"
   },
   "dependencies": {
-    "@parse/node-apn": "5.0.0",
+    "@parse/node-apn": "5.1.0",
     "@parse/node-gcm": "1.0.2",
     "npmlog": "4.1.2",
     "parse": "3.3.0"

--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -183,6 +183,8 @@ describe('APNS', () => {
       'sound': 'test',
       'content-available': 1,
       'mutable-content': 1,
+      'targetContentIdentifier': 'window1',
+      'interruptionLevel': 'passive',
       'category': 'INVITE_CATEGORY',
       'threadId': 'a-thread-id',
       'key': 'value',
@@ -200,6 +202,8 @@ describe('APNS', () => {
     expect(notification.aps.sound).toEqual(data.sound);
     expect(notification.aps['content-available']).toEqual(1);
     expect(notification.aps['mutable-content']).toEqual(1);
+    expect(notification.aps['target-content-id']).toEqual('window1');
+    expect(notification.aps['interruption-level']).toEqual('passive');
     expect(notification.aps.category).toEqual(data.category);
     expect(notification.aps['thread-id']).toEqual(data.threadId);
     expect(notification.payload).toEqual({

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -199,6 +199,12 @@ export class APNS {
           let isMutable = coreData['mutable-content'] === 1;
           notification.setMutableContent(isMutable);
           break;
+        case 'targetContentIdentifier':
+          notification.setTargetContentIdentifier(coreData.targetContentIdentifier);
+          break;
+        case 'interruptionLevel':
+          notification.setInterruptionLevel(coreData.interruptionLevel);
+          break;
         case 'category':
           notification.setCategory(coreData.category);
           break;


### PR DESCRIPTION
This PR along with https://github.com/parse-community/node-apn/pull/87 adds support for specification of `target-content-id` and `interruption-level` in APNS push notification payload to address https://github.com/parse-community/parse-server-push-adapter/issues/196 and https://github.com/parse-community/parse-server-push-adapter/issues/155.