### PR TITLE
ci: Fix CI not running due to outdated ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ '**' ]
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues?q=is%3Aissue).

### Issue Description

Ubuntu version is outdated.

Related issue: #n/a

### Approach

Set ubuntu to `latest`.

