### PR TITLE
ci: Add Node versions to test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,41 @@
 name: ci
 on:
   push:
-    branches: [ master, release, alpha, beta ]
+    branches:
+      - master
   pull_request:
-    branches: [ '**' ]
+    branches:
+      - '**'
 jobs:
   test:
+    strategy:
+      matrix:
+        include:
+          - name: Node.js 14
+            NODE_VERSION: 14
+          - name: Node.js 16
+            NODE_VERSION: 16
+          - name: Node.js 18
+            NODE_VERSION: 18
+          - name: Node.js 20
+            NODE_VERSION: 20
+      fail-fast: false
+    name: ${{ matrix.name }}
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.NODE_VERSION }}
+        uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: ${{ matrix.NODE_VERSION }}
       - name: Cache Node.js modules
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-              ${{ runner.os }}-node-
+              ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-
       - name: Install dependencies
         run: npm ci
       - name: Build package


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues?q=is%3Aissue).

### Issue Description

CI tests only against Node 14.

Related issue: #n/a

### Approach

Add Node version matrix to CI to test against multiple Node versions.

