### PR TITLE
feat: Add Firebase Cloud Messaging (FCM) HTTP/2 support and option `fcmEnableLegacyHttpTransport` to use legacy HTTP/1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ The official Push Notification adapter for Parse Server. See [Parse Server Push 
 - [Configure Parse Server](#configure-parse-server)
   - [Apple Push Options](#apple-push-options)
   - [Android Push Options](#android-push-options)
+  - [Firebase Cloud Messaging (FCM)](#firebase-cloud-messaging-fcm)
     - [Google Cloud Service Account Key](#google-cloud-service-account-key)
     - [Migration to FCM HTTP v1 API (June 2024)](#migration-to-fcm-http-v1-api-june-2024)
+    - [HTTP/1.1 Legacy Option](#http11-legacy-option)
   - [Expo Push Options](#expo-push-options)
 - [Bundled with Parse Server](#bundled-with-parse-server)
 - [Logging](#logging)
@@ -110,6 +112,10 @@ android: {
 }
 ```
 
+### Firebase Cloud Messaging (FCM)
+
+This section contains some considerations when using FCM, regardless of the destination ecosystems the push notification is sent to.
+
 #### Google Cloud Service Account Key
 
 The Firebase console allows to easily create and download a Google Cloud service account key JSON file with the required permissions. Instead of setting `firebaseServiceAccount` to the path of the JSON file, you can provide an object representing a Google Cloud service account key:
@@ -130,15 +136,25 @@ This can be helpful if you are already managing credentials to Google Cloud APIs
 
 ⚠️ Sending push notifications to Android devices via the FCM legacy API was deprecated on June 20 2023 and was announced to be decommissioned in June 2024. See [Google docs](https://firebase.google.com/docs/cloud-messaging/migrate-v1). To send push notifications to the newer FCM HTTP v1 API you need to update your existing push configuration for Android by replacing the key `apiKey` with `firebaseServiceAccount`.
 
-With the update to FCMv1, HTTP/2 support was added which provides much faster throughput for push notifications.
-To use the older deprecated transport method (HTTP/1.1) set the key `fcmEnableLegacyHttpTransport` to `true` under your push options.
-
 Example options (deprecated):
 
 ```js
 android: {
   // Deliver push notifications via FCM legacy API (deprecated)
   apiKey: '<API_KEY>'
+}
+```
+
+#### HTTP/1.1 Legacy Option
+
+With the introduction of the FCM HTTP v1 API, support for HTTP/2 was added which provides faster throughput for push notifications. To use the older version HTTP/1.1 set `fcmEnableLegacyHttpTransport: true` in your push options.
+
+Example options:
+
+```js
+android: {
+  firebaseServiceAccount: __dirname + '/firebase.json',
+  fcmEnableLegacyHttpTransport: true
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Replace `<VERSION>` with the version you want to install.
 ## Configure Parse Server
 
 ```js
-import { ParsePushAdapter } from "@parse/push-adapter";
+import { ParsePushAdapter } from '@parse/push-adapter';
 
 // For CommonJS replace the import statemtent above with the following line:
 // const ParsePushAdapter = require('@parse/push-adapter').default;
@@ -55,9 +55,9 @@ const parseServerOptions = {
       },
       expo: {
         // Expo push options
-      },
-    }),
-  },
+      }
+    })
+  }
   // Other Parse Server options
 };
 ```
@@ -72,8 +72,8 @@ Parse Server Push Adapter currently supports these types of Apple ecosystems:
 
 Delivering push notifications to Apple devices can be done either via Apple Push Notification Service (APNS), or via Firebase Cloud Messaging (FMC). Note that each category of Apple devices require their own configuration section:
 
-- APNS requires a private key that can be downloaded from the Apple Developer Center at <https://developer.apple.com/account> under _Certificates > Identifiers & Profiles._ The adapter options also require the app ID and team ID which can be found there.
-- FCM requires a private key that can be downloaded from the Firebase Console at <https://console.firebase.google.com> in your project under _Settings > Cloud Messaging._
+- APNS requires a private key that can be downloaded from the Apple Developer Center at https://developer.apple.com/account under _Certificates > Identifiers & Profiles._ The adapter options also require the app ID and team ID which can be found there.
+- FCM requires a private key that can be downloaded from the Firebase Console at https://console.firebase.google.com in your project under _Settings > Cloud Messaging._
 
 Example options:
 
@@ -100,13 +100,13 @@ osx: {
 
 Delivering push notifications to Android devices can be done via Firebase Cloud Messaging (FCM):
 
-- FCM requires a private key that can be downloaded from the Firebase Console at <https://console.firebase.google.com> in your project under _Settings > Cloud Messaging._
+- FCM requires a private key that can be downloaded from the Firebase Console at https://console.firebase.google.com in your project under _Settings > Cloud Messaging._
 
 Example options:
 
 ```js
 android: {
-  firebaseServiceAccount: __dirname + "/firebase.json";
+  firebaseServiceAccount: __dirname + '/firebase.json'
 }
 ```
 
@@ -138,7 +138,7 @@ Example options (deprecated):
 ```js
 android: {
   // Deliver push notifications via FCM legacy API (deprecated)
-  apiKey: "<API_KEY>";
+  apiKey: '<API_KEY>'
 }
 ```
 
@@ -148,7 +148,7 @@ Example options:
 
 ```js
 expo: {
-  accessToken: "<EXPO_ACCESS_TOKEN>";
+  accessToken: '<EXPO_ACCESS_TOKEN>'
 }
 ```
 
@@ -165,9 +165,9 @@ const parseServerOptions = {
   push: {
     ios: {
       // Apple push options
-    },
+    }
     // Other push options
-  },
+  }
   // Other Parse Server options
 };
 ```
@@ -177,11 +177,11 @@ const parseServerOptions = {
 You can enable verbose logging to produce a more detailed output for all push sending attempts with the following environment variables:
 
 ```js
-VERBOSE = 1;
+VERBOSE=1
 ```
 
 or
 
 ```js
-VERBOSE_PARSE_SERVER_PUSH_ADAPTER = 1;
+VERBOSE_PARSE_SERVER_PUSH_ADAPTER=1
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This can be helpful if you are already managing credentials to Google Cloud APIs
 ⚠️ Sending push notifications to Android devices via the FCM legacy API was deprecated on June 20 2023 and was announced to be decommissioned in June 2024. See [Google docs](https://firebase.google.com/docs/cloud-messaging/migrate-v1). To send push notifications to the newer FCM HTTP v1 API you need to update your existing push configuration for Android by replacing the key `apiKey` with `firebaseServiceAccount`.
 
 With the update to FCMv1, HTTP/2 support was added which provides much faster throughput for push notifications.
-To use the legacy transport (HTTP/1.1) set the key `fcmEnableLegacyHttpTransport` to `true` under your push options.
+To use the older deprecated transport method (HTTP/1.1) set the key `fcmEnableLegacyHttpTransport` to `true` under your push options.
 
 Example options (deprecated):
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Replace `<VERSION>` with the version you want to install.
 ## Configure Parse Server
 
 ```js
-import { ParsePushAdapter } from '@parse/push-adapter';
+import { ParsePushAdapter } from "@parse/push-adapter";
 
 // For CommonJS replace the import statemtent above with the following line:
 // const ParsePushAdapter = require('@parse/push-adapter').default;
@@ -55,9 +55,9 @@ const parseServerOptions = {
       },
       expo: {
         // Expo push options
-      }
-    })
-  }
+      },
+    }),
+  },
   // Other Parse Server options
 };
 ```
@@ -72,8 +72,8 @@ Parse Server Push Adapter currently supports these types of Apple ecosystems:
 
 Delivering push notifications to Apple devices can be done either via Apple Push Notification Service (APNS), or via Firebase Cloud Messaging (FMC). Note that each category of Apple devices require their own configuration section:
 
-- APNS requires a private key that can be downloaded from the Apple Developer Center at https://developer.apple.com/account under _Certificates > Identifiers & Profiles._ The adapter options also require the app ID and team ID which can be found there.
-- FCM requires a private key that can be downloaded from the Firebase Console at https://console.firebase.google.com in your project under _Settings > Cloud Messaging._
+- APNS requires a private key that can be downloaded from the Apple Developer Center at <https://developer.apple.com/account> under _Certificates > Identifiers & Profiles._ The adapter options also require the app ID and team ID which can be found there.
+- FCM requires a private key that can be downloaded from the Firebase Console at <https://console.firebase.google.com> in your project under _Settings > Cloud Messaging._
 
 Example options:
 
@@ -100,13 +100,13 @@ osx: {
 
 Delivering push notifications to Android devices can be done via Firebase Cloud Messaging (FCM):
 
-- FCM requires a private key that can be downloaded from the Firebase Console at https://console.firebase.google.com in your project under _Settings > Cloud Messaging._
+- FCM requires a private key that can be downloaded from the Firebase Console at <https://console.firebase.google.com> in your project under _Settings > Cloud Messaging._
 
 Example options:
 
 ```js
 android: {
-  firebaseServiceAccount: __dirname + '/firebase.json'
+  firebaseServiceAccount: __dirname + "/firebase.json";
 }
 ```
 
@@ -130,12 +130,15 @@ This can be helpful if you are already managing credentials to Google Cloud APIs
 
 ⚠️ Sending push notifications to Android devices via the FCM legacy API was deprecated on June 20 2023 and was announced to be decommissioned in June 2024. See [Google docs](https://firebase.google.com/docs/cloud-messaging/migrate-v1). To send push notifications to the newer FCM HTTP v1 API you need to update your existing push configuration for Android by replacing the key `apiKey` with `firebaseServiceAccount`.
 
+With the update to FCMv1, HTTP/2 support was added which provides much faster throughput for push notifications.
+To use the legacy transport (HTTP/1.1) set the key `fcmEnableLegacyHttpTransport` to `true` under your push options.
+
 Example options (deprecated):
 
 ```js
 android: {
   // Deliver push notifications via FCM legacy API (deprecated)
-  apiKey: '<API_KEY>'
+  apiKey: "<API_KEY>";
 }
 ```
 
@@ -145,7 +148,7 @@ Example options:
 
 ```js
 expo: {
-  accessToken: '<EXPO_ACCESS_TOKEN>'
+  accessToken: "<EXPO_ACCESS_TOKEN>";
 }
 ```
 
@@ -162,9 +165,9 @@ const parseServerOptions = {
   push: {
     ios: {
       // Apple push options
-    }
+    },
     // Other push options
-  }
+  },
   // Other Parse Server options
 };
 ```
@@ -174,11 +177,11 @@ const parseServerOptions = {
 You can enable verbose logging to produce a more detailed output for all push sending attempts with the following environment variables:
 
 ```js
-VERBOSE=1
+VERBOSE = 1;
 ```
 
 or
 
 ```js
-VERBOSE_PARSE_SERVER_PUSH_ADAPTER=1
+VERBOSE_PARSE_SERVER_PUSH_ADAPTER = 1;
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@parse/node-apn": "6.0.1",
         "@parse/node-gcm": "1.0.2",
         "expo-server-sdk": "3.10.0",
-        "firebase-admin": "12.2.0",
+        "firebase-admin": "12.3.0",
         "npmlog": "7.0.1",
         "parse": "5.2.0",
         "web-push": "3.6.7"
@@ -224,12 +224,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.0.0.tgz",
+      "integrity": "sha512-83rnH2nCvclWaPQQKvkJ2pdOjG4TZyEVuFDnlOF6KP08lDaaceVyw/W63mDuafQT+MKHCvXIPpE5uYWeM0rT4w=="
     },
     "node_modules/@firebase/app-check-interop-types": {
       "version": "0.3.0",
@@ -3479,19 +3476,17 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.2.0.tgz",
-      "integrity": "sha512-R9xxENvPA/19XJ3mv0Kxfbz9kPXd9/HrM4083LZWOO0qAQGheRzcCQamYRe+JSrV2cdKXP3ZsfFGTYMrFM0pJg==",
-      "license": "Apache-2.0",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.3.0.tgz",
+      "integrity": "sha512-AKJcFbOZ7W8Fwcqh6Ba7FThXVoXwPdsf+E9vyjk5Z1vN1Z9mnTw88EQWfIsR91YglQ0KvWu1rvMhW65bcB4sog==",
       "dependencies": {
-        "@fastify/busboy": "^2.1.0",
+        "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^1.0.2",
         "@firebase/database-types": "^1.0.0",
         "@types/node": "^20.10.3",
         "farmhash-modern": "^1.1.0",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "long": "^5.2.3",
         "node-forge": "^1.3.1",
         "uuid": "^10.0.0"
       },
@@ -4958,7 +4953,8 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/lru-cache": {
       "version": "10.3.1",
@@ -10202,9 +10198,9 @@
       "dev": true
     },
     "@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.0.0.tgz",
+      "integrity": "sha512-83rnH2nCvclWaPQQKvkJ2pdOjG4TZyEVuFDnlOF6KP08lDaaceVyw/W63mDuafQT+MKHCvXIPpE5uYWeM0rT4w=="
     },
     "@firebase/app-check-interop-types": {
       "version": "0.3.0",
@@ -12606,11 +12602,11 @@
       }
     },
     "firebase-admin": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.2.0.tgz",
-      "integrity": "sha512-R9xxENvPA/19XJ3mv0Kxfbz9kPXd9/HrM4083LZWOO0qAQGheRzcCQamYRe+JSrV2cdKXP3ZsfFGTYMrFM0pJg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.3.0.tgz",
+      "integrity": "sha512-AKJcFbOZ7W8Fwcqh6Ba7FThXVoXwPdsf+E9vyjk5Z1vN1Z9mnTw88EQWfIsR91YglQ0KvWu1rvMhW65bcB4sog==",
       "requires": {
-        "@fastify/busboy": "^2.1.0",
+        "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^1.0.2",
         "@firebase/database-types": "^1.0.0",
         "@google-cloud/firestore": "^7.7.0",
@@ -12619,7 +12615,6 @@
         "farmhash-modern": "^1.1.0",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "long": "^5.2.3",
         "node-forge": "^1.3.1",
         "uuid": "^10.0.0"
       },
@@ -13742,7 +13737,8 @@
     "long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "optional": true
     },
     "lru-cache": {
       "version": "10.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@parse/node-apn": "6.0.1",
     "@parse/node-gcm": "1.0.2",
     "expo-server-sdk": "3.10.0",
-    "firebase-admin": "12.2.0",
+    "firebase-admin": "12.3.0",
     "npmlog": "7.0.1",
     "parse": "5.2.0",
     "web-push": "3.6.7"

--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import log from 'npmlog';
 import FCM from '../src/FCM.js';
+import { getApps, deleteApp } from 'firebase-admin/app';
 
 const testArgs = {
   firebaseServiceAccount: path.join(
@@ -13,6 +14,10 @@ const testArgs = {
 };
 
 describe('FCM', () => {
+  beforeEach(async () => {
+    getApps().forEach(app => deleteApp(app));
+  });
+
   it('can initialize', () => {
     const fcm = new FCM(testArgs);
     expect(fcm).toBeDefined();

--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -31,6 +31,37 @@ describe('FCM', () => {
     expect(spy).toHaveBeenCalledWith('parse-server-push-adapter FCM', 'invalid push payload');
   });
 
+  it('initializes with fcmEnableLegacyHttpTransport set to false by default', () => {
+    const fcm = new FCM(testArgs);
+    expect(fcm).toBeDefined();
+    expect(fcm.sender).toBeDefined();
+    expect(fcm.sender.useLegacyTransport).toEqual(false)
+  });
+
+  it('can initialize with fcmEnableLegacyHttpTransport set to false', () => {
+    const legacyHttpTransportArgs = {
+      ...testArgs,
+      fcmEnableLegacyHttpTransport: false
+    };
+
+    const fcm = new FCM(legacyHttpTransportArgs);
+    expect(fcm).toBeDefined();
+    expect(fcm.sender).toBeDefined();
+    expect(fcm.sender.useLegacyTransport).toEqual(false)
+  });
+
+  it('can initialize with fcmEnableLegacyHttpTransport set to true', () => {
+    const legacyHttpTransportArgs = {
+      ...testArgs,
+      fcmEnableLegacyHttpTransport: true
+    };
+
+    const fcm = new FCM(legacyHttpTransportArgs);
+    expect(fcm).toBeDefined();
+    expect(fcm.sender).toBeDefined();
+    expect(fcm.sender.useLegacyTransport).toEqual(true)
+  });
+
   it('can send successful FCM android request', async () => {
     const spyVerbose = spyOn(log, 'verbose').and.callFake(() => {});
     const spyInfo = spyOn(log, 'info').and.callFake(() => {});

--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -35,7 +35,7 @@ describe('FCM', () => {
     const fcm = new FCM(testArgs);
     expect(fcm).toBeDefined();
     expect(fcm.sender).toBeDefined();
-    expect(fcm.sender.useLegacyTransport).toEqual(false)
+    expect(fcm.sender.useLegacyTransport).toEqual(false);
   });
 
   it('can initialize with fcmEnableLegacyHttpTransport set to false', () => {
@@ -47,7 +47,7 @@ describe('FCM', () => {
     const fcm = new FCM(legacyHttpTransportArgs);
     expect(fcm).toBeDefined();
     expect(fcm.sender).toBeDefined();
-    expect(fcm.sender.useLegacyTransport).toEqual(false)
+    expect(fcm.sender.useLegacyTransport).toEqual(false);
   });
 
   it('can initialize with fcmEnableLegacyHttpTransport set to true', () => {
@@ -59,7 +59,7 @@ describe('FCM', () => {
     const fcm = new FCM(legacyHttpTransportArgs);
     expect(fcm).toBeDefined();
     expect(fcm.sender).toBeDefined();
-    expect(fcm.sender.useLegacyTransport).toEqual(true)
+    expect(fcm.sender.useLegacyTransport).toEqual(true);
   });
 
   it('can send successful FCM android request', async () => {

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -36,17 +36,15 @@ export default function FCM(args, pushType) {
     app = getApp();
   }
 
-
-  this.sender = getMessaging(app)
+  this.sender = getMessaging(app);
 
   if (fcmEnableLegacyHttpTransport) {
-    this.sender.enableLegacyHttpTransport()
-    log.warn(LOG_PREFIX, 'Legacy HTTP/1.1 transport is enabled. This is a deprecated feature and support for this flag will be removed in the future.')
-  } else {
-    this.sender.useLegacyTransport = false // Flaky tests unless we explicitly set this to false
+    this.sender.enableLegacyHttpTransport();
+    log.warn(LOG_PREFIX, 'Legacy HTTP/1.1 transport is enabled. This is a deprecated feature and support for this flag will be removed in the future.');
   }
 
-  this.pushType = pushType; // Push type is only used to remain backwards compatible with APNS and GCM
+  // Push type is only used to remain backwards compatible with APNS and GCM
+  this.pushType = pushType;
 }
 
 FCM.FCMRegistrationTokensMax = FCMRegistrationTokensMax;

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -36,11 +36,14 @@ export default function FCM(args, pushType) {
     app = getApp();
   }
 
+
+  this.sender = getMessaging(app)
+
   if (fcmEnableLegacyHttpTransport) {
-    this.sender = getMessaging(app).enableLegacyHttpTransport();
+    this.sender.enableLegacyHttpTransport()
     log.warn(LOG_PREFIX, 'Legacy HTTP/1.1 transport is enabled. This is a deprecated feature and support for this flag will be removed in the future.')
   } else {
-    this.sender = getMessaging(app);
+    this.sender.useLegacyTransport = false // Flaky tests unless we explicitly set this to false
   }
 
   this.pushType = pushType; // Push type is only used to remain backwards compatible with APNS and GCM

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -25,12 +25,24 @@ export default function FCM(args, pushType) {
     );
   }
 
+  const fcmEnableLegacyHttpTransport = typeof args.fcmEnableLegacyHttpTransport === 'boolean'
+    ? args.fcmEnableLegacyHttpTransport
+    : false;
+
   let app;
   if (getApps().length === 0) {
     app = initializeApp({ credential: cert(args.firebaseServiceAccount) });
   } else {
     app = getApp();
   }
+
+  if (fcmEnableLegacyHttpTransport) {
+    this.sender = getMessaging(app).enableLegacyHttpTransport();
+    log.warn(LOG_PREFIX, 'Legacy HTTP/1.1 transport is enabled. This is a deprecated feature and support for this flag will be removed in the future.')
+  } else {
+    this.sender = getMessaging(app);
+  }
+
   this.sender = getMessaging(app);
   this.pushType = pushType; // Push type is only used to remain backwards compatible with APNS and GCM
 }

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -43,7 +43,6 @@ export default function FCM(args, pushType) {
     this.sender = getMessaging(app);
   }
 
-  this.sender = getMessaging(app);
   this.pushType = pushType; // Push type is only used to remain backwards compatible with APNS and GCM
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues/251).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
firebase-admin recently added support to this in the release of [v12.3.0](https://github.com/firebase/firebase-admin-node/releases/tag/v12.3.0).


Closes: #251 
### Approach
- Bump version to v12.3.0. 
- Provide new flag in push options for FCM to enable legacy HTTP transport if wanted.

Tested and working.