### PR TITLE
FIX: iOS Alert property is overwriting iOS Title property

### DIFF
--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -149,7 +149,7 @@ describe('FCM', () => {
     }]]);
   });
 
-  it('can send successful FCM apple request with title', async () => {
+  it('can send successful FCM apple request with title and alert', async () => {
     const spyVerbose = spyOn(log, 'verbose').and.callFake(() => {});
     const spyInfo = spyOn(log, 'info').and.callFake(() => {});
     const fcm = new FCM(testArgs);
@@ -159,13 +159,13 @@ describe('FCM', () => {
       });
     });
     fcm.pushType = 'apple';
-    const data = { data: { title: 'title' } };
+    const data = { data: { title: 'title', alert: 'alert' } };
     const devices = [{ deviceToken: 'token' }];
     const response = await fcm.send(data, devices);
     expect(fcm.sender.sendEachForMulticast).toHaveBeenCalled();
     const args = fcm.sender.sendEachForMulticast.calls.first().args;
     expect(args.length).toEqual(1);
-    expect(args[0].apns.payload).toEqual({ aps: { alert: { title: 'title' } } });
+    expect(args[0].apns.payload).toEqual({ aps: { alert: { title: 'title', body: 'alert' } } });
     expect(args[0].apns.headers).toEqual({ 'apns-push-type': 'alert' });
     expect(args[0].tokens).toEqual(['token']);
     expect(spyVerbose).toHaveBeenCalledWith('parse-server-push-adapter FCM', 'tokens with successful pushes: ["token"]');


### PR DESCRIPTION


### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues?q=is%3Aissue).

### Issue Description
When `title` and `alert` are provided as a strings, the adapter code has to convert the Parse dictionary to the format that FCM is expecting. This would set the title property first and then reinitialize the alert key before setting the alert. This would wipe out the title property.

Related issue: #286 

### Approach
In the switch statement where both alert and title get set, the title property was correctly checking if the alert property was already set before initializing it. All I had to do was copy that code up to the `alert` case.

### TODOs before merging
<!--
    Provide a sample payload in the documentation.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)