### PR TITLE
feat: Add FCM option `resolveUnhandledClientError` to resolve or reject push promise on FCM server response GOAWAY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ node_modules
 
 # Optional eslint cache
 .eslintcache
+.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ android: {
 Occasionally, errors within the Firebase Cloud Messaging (FCM) client may not be managed internally and are instead passed to the Parse Server Push Adapter. These errors can occur, for instance, due to unhandled FCM server connection issues.
 
 - `fcmResolveUnhandledClientError: true`: Logs the error and gracefully resolves it, ensuring that push sending does not result in a failure.
-- `fcmResolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to take action. This is the default.
+- `fcmResolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to handle it accordingly. This is the default.
 
 In both cases, detailed error logs are recorded in the Parse Server logs for debugging purposes.
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ android: {
 
 Occasionally, errors within the Firebase Cloud Messaging (FCM) client may not be managed internally and are instead passed to the Parse Server Push Adapter. These errors can occur, for instance, due to unhandled FCM server connection issues.
 
-- `fcmResolveUnhandledClientError: true`: Logs the error and gracefully resolves it, ensuring that push sending does not result in a failure.
-- `fcmResolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to handle it accordingly. This is the default.
+- `resolveUnhandledClientError: true`: Logs the error and gracefully resolves it, ensuring that push sending does not result in a failure.
+- `resolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to handle it accordingly. This is the default.
 
 In both cases, detailed error logs are recorded in the Parse Server logs for debugging purposes.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The official Push Notification adapter for Parse Server. See [Parse Server Push 
     - [Google Cloud Service Account Key](#google-cloud-service-account-key)
     - [Migration to FCM HTTP v1 API (June 2024)](#migration-to-fcm-http-v1-api-june-2024)
     - [HTTP/1.1 Legacy Option](#http11-legacy-option)
+    - [Firebase Client Error](#firebase-client-error)
   - [Expo Push Options](#expo-push-options)
 - [Bundled with Parse Server](#bundled-with-parse-server)
 - [Logging](#logging)
@@ -157,6 +158,15 @@ android: {
   fcmEnableLegacyHttpTransport: true
 }
 ```
+
+#### Firebase Client Error
+
+Occasionally, errors within the Firebase Cloud Messaging (FCM) client may not be managed internally and are instead passed to the Parse Server Push Adapter. These errors can occur, for instance, due to unhandled FCM server connection issues.
+
+- `fcmResolveUnhandledClientError: true`: Logs the error and gracefully resolves it, ensuring that push sending does not result in a failure.
+- `fcmResolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to take action.
+
+In both cases, detailed error logs are recorded in the Parse Server logs for debugging purposes.
 
 ### Expo Push Options
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ android: {
 Occasionally, errors within the Firebase Cloud Messaging (FCM) client may not be managed internally and are instead passed to the Parse Server Push Adapter. These errors can occur, for instance, due to unhandled FCM server connection issues.
 
 - `fcmResolveUnhandledClientError: true`: Logs the error and gracefully resolves it, ensuring that push sending does not result in a failure.
-- `fcmResolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to take action.
+- `fcmResolveUnhandledClientError: false`: Causes push sending to fail, returning a `Parse.Error.OTHER_CAUSE` with error details that can be parsed to take action. This is the default.
 
 In both cases, detailed error logs are recorded in the Parse Server logs for debugging purposes.
 

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "env": {
+        "jasmine": true
+    },
+    "globals": {
+      "Parse": true
+    },
+    "rules": {
+      "no-console": [0],
+      "no-var": "error"
+    }
+}

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -3,8 +3,7 @@
         "jasmine": true
     },
     "globals": {
-      "Parse": true,
-      "expectAsync": true
+      "Parse": true
     },
     "rules": {
       "no-console": [0],

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -3,7 +3,8 @@
         "jasmine": true
     },
     "globals": {
-      "Parse": true
+      "Parse": true,
+      "expectAsync": true
     },
     "rules": {
       "no-console": [0],

--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -235,7 +235,7 @@ describe('FCM', () => {
     expect(fcm.sender.sendEachForMulticast).toHaveBeenCalled();
     expect(spyInfo).toHaveBeenCalledWith('parse-server-push-adapter FCM', 'sending push to 1 devices');
     expect(spyError).toHaveBeenCalledTimes(2);
-    expect(spyError.calls.all()[0].args).toEqual(['parse-server-push-adapter FCM', 'error sending push: firebase-admin client did not handle exception: Error: test error']);
+    expect(spyError.calls.all()[0].args).toEqual(['parse-server-push-adapter FCM', 'error sending push: firebase client did not handle exception: Error: test error']);
     expect(spyError.calls.all()[1].args).toEqual(['parse-server-push-adapter FCM', 'error sending push: Error: test error']);
   });
 

--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -1,8 +1,8 @@
-import path from 'path';
+import { deleteApp, getApps } from 'firebase-admin/app';
 import log from 'npmlog';
-import FCM from '../src/FCM.js';
-import { getApps, deleteApp } from 'firebase-admin/app';
 import Parse from 'parse/node.js';
+import path from 'path';
+import FCM from '../src/FCM.js';
 
 let testArgs;
 
@@ -227,7 +227,7 @@ describe('FCM', () => {
   it('rejects exceptions that are unhandled by FCM client', async () => {
     const spyInfo = spyOn(log, 'info').and.callFake(() => {});
     const spyError = spyOn(log, 'error').and.callFake(() => {});
-    testArgs.fcmResolveUnhandledClientError = false;
+    testArgs.resolveUnhandledClientError = false;
     const fcm = new FCM(testArgs);
     spyOn(fcm.sender, 'sendEachForMulticast').and.callFake(() => {
       throw new Error('test error');
@@ -246,7 +246,7 @@ describe('FCM', () => {
   it('resolves exceptions that are unhandled by FCM client', async () => {
     const spyInfo = spyOn(log, 'info').and.callFake(() => {});
     const spyError = spyOn(log, 'error').and.callFake(() => {});
-    testArgs.fcmResolveUnhandledClientError = true;
+    testArgs.resolveUnhandledClientError = true;
     const fcm = new FCM(testArgs);
     spyOn(fcm.sender, 'sendEachForMulticast').and.callFake(() => {
       throw new Error('test error');

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -144,6 +144,26 @@ FCM.prototype.send = function (data, devices) {
     log.error(LOG_PREFIX, `error sending push: ${err}`);
   });
 
+  // const allPromises = Promise.all(
+  //   slices.map(slice =>
+  //     new Promise((resolve, reject) => {
+  //       try {
+  //         sendToDeviceSlice(slice, this.pushType)
+  //           .then(resolve)
+  //           .catch((err) => {
+  //             log.error(LOG_PREFIX, `error sending push (rejected by client): ${err}`);
+  //             reject(err);
+  //           });
+  //       } catch (err) {
+  //         log.error(LOG_PREFIX, `error sending push (unhandled by client): ${err}`);
+  //         reject(err);
+  //       }
+  //     })
+  //   )
+  // ).catch(err => {
+  //   log.error(LOG_PREFIX, `error sending push: ${err}`);
+  // });
+
   return allPromises;
 };
 

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -154,26 +154,6 @@ FCM.prototype.send = function (data, devices) {
     log.error(LOG_PREFIX, `error sending push: ${err}`);
   });
 
-  // const allPromises = Promise.all(
-  //   slices.map(slice =>
-  //     new Promise((resolve, reject) => {
-  //       try {
-  //         sendToDeviceSlice(slice, this.pushType)
-  //           .then(resolve)
-  //           .catch((err) => {
-  //             log.error(LOG_PREFIX, `error sending push (rejected by client): ${err}`);
-  //             reject(err);
-  //           });
-  //       } catch (err) {
-  //         log.error(LOG_PREFIX, `error sending push (unhandled by client): ${err}`);
-  //         reject(err);
-  //       }
-  //     })
-  //   )
-  // ).catch(err => {
-  //   log.error(LOG_PREFIX, `error sending push: ${err}`);
-  // });
-
   return allPromises;
 };
 

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -1,9 +1,9 @@
 'use strict';
 
-import Parse from 'parse';
-import log from 'npmlog';
-import { initializeApp, cert, getApps, getApp } from 'firebase-admin/app';
+import { cert, getApp, getApps, initializeApp } from 'firebase-admin/app';
 import { getMessaging } from 'firebase-admin/messaging';
+import log from 'npmlog';
+import Parse from 'parse';
 import { randomString } from './PushAdapterUtils.js';
 
 const LOG_PREFIX = 'parse-server-push-adapter FCM';
@@ -28,8 +28,8 @@ export default function FCM(args, pushType) {
   const fcmEnableLegacyHttpTransport = typeof args.fcmEnableLegacyHttpTransport === 'boolean'
     ? args.fcmEnableLegacyHttpTransport
     : false;
-  this.fcmResolveUnhandledClientError = typeof args.fcmResolveUnhandledClientError === 'boolean'
-    ? args.fcmResolveUnhandledClientError
+  this.resolveUnhandledClientError = typeof args.resolveUnhandledClientError === 'boolean'
+    ? args.resolveUnhandledClientError
     : false;
 
   let app;
@@ -155,7 +155,7 @@ FCM.prototype.send = function (data, devices) {
     slices.map((slice) => sendToDeviceSlice(slice, this.pushType)),
   ).catch(e => {
     log.error(LOG_PREFIX, `error sending push: ${e}`);
-    if (!this.fcmResolveUnhandledClientError && e instanceof Parse.Error && e.code === Parse.Error.OTHER_CAUSE) {
+    if (!this.resolveUnhandledClientError && e instanceof Parse.Error && e.code === Parse.Error.OTHER_CAUSE) {
       return Promise.reject(e);
     }
   });

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -94,7 +94,7 @@ FCM.prototype.send = function (data, devices) {
       try {
         return this.sender.sendEachForMulticast(fcmPayloadData);
       } catch (err) {
-        log.error(LOG_PREFIX, `error sending push: firebase-admin client did not handle exception: ${err}`);
+        log.error(LOG_PREFIX, `error sending push: firebase client did not handle exception: ${err}`);
         return Promise.reject(err);
       }
     };


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues?q=is%3Aissue).

### Issue Description

Closes: #340 

### Approach

- Wrap push sending into try/catch block as firebase-admin client throws instead of rejecting promise.
- Add new FCM option `resolveUnhandledClientError` that allows to customize whether client errors should be gracefully resolved (set to `true`), or lead to a promise rejection for the caller to indicate that sending the push failed (set to `false`). Default is `false`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
