### PR TITLE
fix: APN notification topic not composed based on push type

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -379,42 +379,42 @@ describe('APNS', () => {
     const topic = 'bundleId';
     const pushType = 'location';
     const updatedTopic = APNS._determineTopic(topic, pushType);
-    expect(updatedTopic).toEqual(topic+'.location-query');
+    expect(updatedTopic).toEqual(topic + '.location-query');
   });
 
   it('updates topic based on voip pushType', async () => {
     const topic = 'bundleId';
     const pushType = 'voip';
     const updatedTopic = APNS._determineTopic(topic, pushType);
-    expect(updatedTopic).toEqual(topic+'.voip');
+    expect(updatedTopic).toEqual(topic + '.voip');
   });
 
   it('updates topic based on complication pushType', async () => {
     const topic = 'bundleId';
     const pushType = 'complication';
     const updatedTopic = APNS._determineTopic(topic, pushType);
-    expect(updatedTopic).toEqual(topic+'.complication');
+    expect(updatedTopic).toEqual(topic + '.complication');
   });
 
   it('updates topic based on complication pushType', async () => {
     const topic = 'bundleId';
     const pushType = 'fileprovider';
     const updatedTopic = APNS._determineTopic(topic, pushType);
-    expect(updatedTopic).toEqual(topic+'.pushkit.fileprovider');
+    expect(updatedTopic).toEqual(topic + '.pushkit.fileprovider');
   });
 
   it('updates topic based on liveactivity pushType', async () => {
     const topic = 'bundleId';
     const pushType = 'liveactivity';
     const updatedTopic = APNS._determineTopic(topic, pushType);
-    expect(updatedTopic).toEqual(topic+'.push-type.liveactivity');
+    expect(updatedTopic).toEqual(topic + '.push-type.liveactivity');
   });
 
   it('updates topic based on pushtotalk pushType', async () => {
     const topic = 'bundleId';
     const pushType = 'pushtotalk';
     const updatedTopic = APNS._determineTopic(topic, pushType);
-    expect(updatedTopic).toEqual(topic+'.voip-ptt');
+    expect(updatedTopic).toEqual(topic + '.voip-ptt');
   });
 
   it('can choose providers for device with valid appIdentifier', (done) => {

--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -368,6 +368,16 @@ describe('APNS', () => {
     expect(notification.priority).toEqual(10);
   });
 
+  it('generating notification updates topic properly', async () => {
+    const data = {};
+    const topic = 'bundleId';
+    const pushType = "liveactivity";
+
+    const notification = APNS._generateNotification(data, { topic: topic, pushType: pushType });
+    expect(notification.topic).toEqual(topic + '.push-type.liveactivity');
+    expect(notification.pushType).toEqual(pushType);
+  });
+
   it('defaults to original topic', async () => {
     const topic = 'bundleId';
     const pushType = 'alert';

--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -324,24 +324,34 @@ describe('APNS', () => {
 
   it('generating notification prioritizes header information from notification data', async () => {
     const data = {
+      'id': 'hello',
+      'requestId': 'world',
+      'channelId': 'foo',
       'topic': 'bundle',
       'expiry': 20,
       'collapseId': 'collapse',
       'pushType': 'alert',
       'priority': 7,
     };
+    const id = 'foo';
+    const requestId = 'hello';
+    const channelId = 'world';
     const topic = 'bundleId';
     const expirationTime = 1454571491354;
     const collapseId = "collapseIdentifier";
     const pushType = "background";
     const priority = 5;
 
-    const notification = APNS._generateNotification(data, { topic: topic, expirationTime: expirationTime, collapseId: collapseId, pushType: pushType, priority: priority });
+    const notification = APNS._generateNotification(data, { id: id, requestId: requestId, channelId: channelId, topic: topic, expirationTime: expirationTime, collapseId: collapseId, pushType: pushType, priority: priority });
+    expect(notification.id).toEqual(data.id);
+    expect(notification.requestId).toEqual(data.requestId);
+    expect(notification.channelId).toEqual(data.channelId);
     expect(notification.topic).toEqual(data.topic);
     expect(notification.expiry).toEqual(data.expiry);
     expect(notification.collapseId).toEqual(data.collapseId);
     expect(notification.pushType).toEqual(data.pushType);
     expect(notification.priority).toEqual(data.priority);
+    expect(Object.keys(notification.payload).length).toBe(0);
   });
 
   it('generating notification does not override default notification info when header info is missing', async () => {

--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -324,16 +324,6 @@ describe('APNS', () => {
 
   it('generating notification prioritizes header information from notification data', async () => {
     const data = {
-      'alert': 'alert',
-      'title': 'title',
-      'badge': 100,
-      'sound': 'test',
-      'content-available': 1,
-      'mutable-content': 1,
-      'category': 'INVITE_CATEGORY',
-      'threadId': 'a-thread-id',
-      'key': 'value',
-      'keyAgain': 'valueAgain',
       'topic': 'bundle',
       'expiry': 20,
       'collapseId': 'collapse',
@@ -355,18 +345,7 @@ describe('APNS', () => {
   });
 
   it('generating notification does not override default notification info when header info is missing', async () => {
-    const data = {
-      'alert': 'alert',
-      'title': 'title',
-      'badge': 100,
-      'sound': 'test',
-      'content-available': 1,
-      'mutable-content': 1,
-      'category': 'INVITE_CATEGORY',
-      'threadId': 'a-thread-id',
-      'key': 'value',
-      'keyAgain': 'valueAgain',
-    };
+    const data = {};
     const topic = 'bundleId';
     const collapseId = "collapseIdentifier";
     const pushType = "background";

--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -322,6 +322,112 @@ describe('APNS', () => {
     done();
   });
 
+  it('generating notification prioritizes header information from notification data', async () => {
+    const data = {
+      'alert': 'alert',
+      'title': 'title',
+      'badge': 100,
+      'sound': 'test',
+      'content-available': 1,
+      'mutable-content': 1,
+      'category': 'INVITE_CATEGORY',
+      'threadId': 'a-thread-id',
+      'key': 'value',
+      'keyAgain': 'valueAgain',
+      'topic': 'bundle',
+      'expiry': 20,
+      'collapseId': 'collapse',
+      'pushType': 'alert',
+      'priority': 7,
+    };
+    const topic = 'bundleId';
+    const expirationTime = 1454571491354;
+    const collapseId = "collapseIdentifier";
+    const pushType = "background";
+    const priority = 5;
+
+    const notification = APNS._generateNotification(data, { topic: topic, expirationTime: expirationTime, collapseId: collapseId, pushType: pushType, priority: priority });
+    expect(notification.topic).toEqual(data.topic);
+    expect(notification.expiry).toEqual(data.expiry);
+    expect(notification.collapseId).toEqual(data.collapseId);
+    expect(notification.pushType).toEqual(data.pushType);
+    expect(notification.priority).toEqual(data.priority);
+  });
+
+  it('generating notification does not override default notification info when header info is missing', async () => {
+    const data = {
+      'alert': 'alert',
+      'title': 'title',
+      'badge': 100,
+      'sound': 'test',
+      'content-available': 1,
+      'mutable-content': 1,
+      'category': 'INVITE_CATEGORY',
+      'threadId': 'a-thread-id',
+      'key': 'value',
+      'keyAgain': 'valueAgain',
+    };
+    const topic = 'bundleId';
+    const collapseId = "collapseIdentifier";
+    const pushType = "background";
+
+    const notification = APNS._generateNotification(data, { topic: topic, collapseId: collapseId, pushType: pushType });
+    expect(notification.topic).toEqual(topic);
+    expect(notification.expiry).toEqual(-1);
+    expect(notification.collapseId).toEqual(collapseId);
+    expect(notification.pushType).toEqual(pushType);
+    expect(notification.priority).toEqual(10);
+  });
+
+  it('defaults to original topic', async () => {
+    const topic = 'bundleId';
+    const pushType = 'alert';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic);
+  });
+
+  it('updates topic based on location pushType', async () => {
+    const topic = 'bundleId';
+    const pushType = 'location';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic+'.location-query');
+  });
+
+  it('updates topic based on voip pushType', async () => {
+    const topic = 'bundleId';
+    const pushType = 'voip';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic+'.voip');
+  });
+
+  it('updates topic based on complication pushType', async () => {
+    const topic = 'bundleId';
+    const pushType = 'complication';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic+'.complication');
+  });
+
+  it('updates topic based on complication pushType', async () => {
+    const topic = 'bundleId';
+    const pushType = 'fileprovider';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic+'.pushkit.fileprovider');
+  });
+
+  it('updates topic based on liveactivity pushType', async () => {
+    const topic = 'bundleId';
+    const pushType = 'liveactivity';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic+'.push-type.liveactivity');
+  });
+
+  it('updates topic based on pushtotalk pushType', async () => {
+    const topic = 'bundleId';
+    const pushType = 'pushtotalk';
+    const updatedTopic = APNS._determineTopic(topic, pushType);
+    expect(updatedTopic).toEqual(topic+'.voip-ptt');
+  });
+
   it('can choose providers for device with valid appIdentifier', (done) => {
     const appIdentifier = 'topic';
     // Mock providers

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -214,12 +214,12 @@ export class APNS {
         notification.setThreadId(coreData.threadId);
         break;
       case 'id':
-      case 'collapseId': 
-      case 'channelId': 
-      case 'requestId': 
+      case 'collapseId':
+      case 'channelId':
+      case 'requestId':
       case 'pushType':
-      case 'topic': 
-      case 'expiry': 
+      case 'topic':
+      case 'expiry':
       case 'priority':
         // Header information is skipped and added later.
         break;
@@ -261,20 +261,20 @@ export class APNS {
    */
   static _determineTopic(topic, pushType) {
     switch(pushType) {
-      case 'location':
-        return topic+'.location-query';
-      case 'voip':
-          return topic+'.voip';
-      case 'complication':
-          return topic+'.complication';
-      case 'fileprovider':
-          return topic+'.pushkit.fileprovider';
-      case 'liveactivity':
-          return topic+'.push-type.liveactivity';
-      case 'pushtotalk':
-          return topic+'.voip-ptt';
-      default:
-        return topic
+    case 'location':
+      return topic + '.location-query';
+    case 'voip':
+      return topic + '.voip';
+    case 'complication':
+      return topic + '.complication';
+    case 'fileprovider':
+      return topic + '.pushkit.fileprovider';
+    case 'liveactivity':
+      return topic + '.push-type.liveactivity';
+    case 'pushtotalk':
+      return topic + '.voip-ptt';
+    default:
+      return topic;
     }
   }
 

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -213,6 +213,16 @@ export class APNS {
       case 'threadId':
         notification.setThreadId(coreData.threadId);
         break;
+      case 'id':
+      case 'collapseId': 
+      case 'channelId': 
+      case 'requestId': 
+      case 'pushType':
+      case 'topic': 
+      case 'expiry': 
+      case 'priority':
+        // Header information is skipped and added later.
+        break;
       default:
         payload[key] = coreData[key];
         break;
@@ -221,19 +231,23 @@ export class APNS {
 
     notification.payload = payload;
 
+    // Update header information if necessary.
+    notification.id = coreData.id ?? headers.id;
+    notification.collapseId = coreData.collapseId ?? headers.collapseId;
+    notification.requestId = coreData.requestId ?? headers.requestId;
+    notification.channelId = coreData.channelId ?? headers.channelId;
     // set alert as default push type. If push type is not set notifications are not delivered to devices running iOS 13, watchOS 6 and later.
-    const pushType = payload.pushType ?? headers.pushType ?? 'alert';
+    const pushType = coreData.pushType ?? headers.pushType ?? 'alert';
     notification.pushType = pushType;
-    const topic = payload.topic ?? APNS._determineTopic(headers.topic, pushType);
+    const topic = coreData.topic ?? APNS._determineTopic(headers.topic, pushType);
     notification.topic = topic;
-    let defaultExpiry = notification.expiry;
+    let expiry = notification.expiry;
     if (headers.expirationTime) {
-      defaultExpiry = Math.round(headers.expirationTime / 1000);
+      expiry = Math.round(headers.expirationTime / 1000);
     }
-    notification.expiry = payload.expiry ?? defaultExpiry;
-    notification.collapseId = payload.collapseId ?? headers.collapseId;
+    notification.expiry = coreData.expiry ?? expiry;
     // if headers priority is not set 'node-apn' defaults it to notification's default value. Required value for background pushes to launch the app in background.
-    notification.priority = payload.priority ?? headers.priority ?? notification.priority;
+    notification.priority = coreData.priority ?? headers.priority ?? notification.priority;
 
     return notification;
   }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
An APN notification `topic` currently stays as the `topic` initialized by the Parse-Server (`_Installation.appIdentifier`) and isn't updated based on `pushType`. Based on the [Apple Documentation](https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns#Know-when-to-use-push-types), a specific `pushType` may require a `topic` to change.  

In addition, the notification header determined by `parse-server-push-adapter` currently has the highest priority. This makes it harder for the developer to specify particular header information in Cloud Code to prioritize over `parse-server-push-adapter` header information (parse-server running in memory). This is also useful when Apple updates/adds new notification types and allows devs to add updates to their respective Cloud Code dynamically and adapt the latest features.

Closes: #348 

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Update notification `topic` based on `pushType`
- [x] Prioritize notification information passed as data over default header information without breaking the current API (see explanation above)
- [x] Clean up code/errors 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests