### PR TITLE
test: Correctly name fileprovider test

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -406,7 +406,7 @@ describe('APNS', () => {
     expect(updatedTopic).toEqual(topic + '.complication');
   });
 
-  it('updates topic based on complication pushType', async () => {
+  it('updates topic based on fileprovider pushType', async () => {
     const topic = 'bundleId';
     const pushType = 'fileprovider';
     const updatedTopic = APNS._determineTopic(topic, pushType);


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Check every following box [x] before submitting your PR.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/parse-server-push-adapter/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/parse-server-push-adapter/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
I named a test incorrectly in #347

Related issue: #`FILL_THIS_OUT`

### Approach
<!-- Add a description of the approach in this PR. -->
Change name of test.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests