### PR TITLE
refactor: Bump firebase-admin from 13.7.0 to 13.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@parse/node-apn": "8.0.0",
         "expo-server-sdk": "6.1.0",
-        "firebase-admin": "13.7.0",
+        "firebase-admin": "13.8.0",
         "npmlog": "7.0.1",
         "parse": "8.5.0",
         "web-push": "3.6.7"
@@ -3547,9 +3547,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -3560,7 +3560,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "engines": {
@@ -12034,9 +12034,9 @@
       }
     },
     "firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "requires": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",
@@ -12048,7 +12048,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@parse/node-apn": "8.0.0",
     "expo-server-sdk": "6.1.0",
-    "firebase-admin": "13.7.0",
+    "firebase-admin": "13.8.0",
     "npmlog": "7.0.1",
     "parse": "8.5.0",
     "web-push": "3.6.7"


### PR DESCRIPTION
Closes #551

## Changes
- Bumps [firebase-admin](https://github.com/firebase/firebase-admin-node) from 13.7.0 to 13.8.0
- [Release notes](https://github.com/firebase/firebase-admin-node/releases/tag/v13.8.0): adds Phone Number Verification support, FCM `bandwidthConstrainedOk` and `restrictedSatelliteOk` options, and dependency bumps (node-forge, fast-xml-parser)

## Breaking Changes
None. This is a minor release with only additive features.

## Code Changes Required
None. The project uses `firebase-admin/app` and `firebase-admin/messaging` APIs which are unchanged.