### PR TITLE
refactor: Bump @parse/node-apn from 8.0.0 to 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
-        "@parse/node-apn": "8.0.0",
+        "@parse/node-apn": "8.1.0",
         "expo-server-sdk": "6.1.0",
         "firebase-admin": "13.8.0",
         "npmlog": "7.0.1",
@@ -859,9 +859,9 @@
       }
     },
     "node_modules/@parse/node-apn": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.0.0.tgz",
-      "integrity": "sha512-blvU/V0FL3j7u2lstso1aInMw7yYrKg/6Ctr3Kc/7kleFatAfZswhzHk9d5lI4DUQBsUBun8nidgZHCY6sft+Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.1.0.tgz",
+      "integrity": "sha512-LowcdkKPDikbbzIr3zwEdoFW5wfEbbTzpYQeen3S8kKLePG0AQK586Li+OLC7bonyLmlk//Yk3smHZOLSV6TZA==",
       "license": "MIT",
       "dependencies": {
         "debug": "4.4.3",
@@ -10108,9 +10108,9 @@
       "optional": true
     },
     "@parse/node-apn": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.0.0.tgz",
-      "integrity": "sha512-blvU/V0FL3j7u2lstso1aInMw7yYrKg/6Ctr3Kc/7kleFatAfZswhzHk9d5lI4DUQBsUBun8nidgZHCY6sft+Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.1.0.tgz",
+      "integrity": "sha512-LowcdkKPDikbbzIr3zwEdoFW5wfEbbTzpYQeen3S8kKLePG0AQK586Li+OLC7bonyLmlk//Yk3smHZOLSV6TZA==",
       "requires": {
         "debug": "4.4.3",
         "jsonwebtoken": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Parse",
   "license": "MIT",
   "dependencies": {
-    "@parse/node-apn": "8.0.0",
+    "@parse/node-apn": "8.1.0",
     "expo-server-sdk": "6.1.0",
     "firebase-admin": "13.8.0",
     "npmlog": "7.0.1",


### PR DESCRIPTION
## Summary

Bumps [@parse/node-apn](https://github.com/parse-community/node-apn) from 8.0.0 to 8.1.0.

### Changelog
- Adds support for the `widgets` push type (Live Activities / widget updates).
- No breaking changes.

### Risk
Low — minor, additive feature release.

Closes #555