### PR TITLE
refactor: Bump jasmine from 6.1.0 to 6.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "c8": "11.0.0",
         "codecov": "3.8.3",
         "eslint": "10.2.0",
-        "jasmine": "6.1.0",
+        "jasmine": "6.2.0",
         "jasmine-spec-reporter": "7.0.0",
         "semantic-release": "25.0.3"
       },
@@ -4678,24 +4678,26 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
-      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
+      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.1.0"
+        "jasmine-core": "~6.2.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
-      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
-      "dev": true
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
+      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "7.0.0",
@@ -12827,20 +12829,20 @@
       }
     },
     "jasmine": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.1.0.tgz",
-      "integrity": "sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
+      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
       "dev": true,
       "requires": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.1.0"
+        "jasmine-core": "~6.2.0"
       }
     },
     "jasmine-core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.1.0.tgz",
-      "integrity": "sha512-p/tjBw58O6vxKIWMlrU+yys8lqR3+l3UrqwNTT7wpj+dQ7N4etQekFM8joI+cWzPDYqZf54kN+hLC1+s5TvZvg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
+      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
       "dev": true
     },
     "jasmine-spec-reporter": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "c8": "11.0.0",
     "codecov": "3.8.3",
     "eslint": "10.2.0",
-    "jasmine": "6.1.0",
+    "jasmine": "6.2.0",
     "jasmine-spec-reporter": "7.0.0",
     "semantic-release": "25.0.3"
   },


### PR DESCRIPTION
Closes #554

## Summary

Replacement PR for Dependabot #554. Bumps `jasmine` from `6.1.0` to `6.2.0` (devDependency, routine minor bump).

## Changelog

- jasmine 6.2.0: routine minor release with minor fixes and improvements; no breaking changes expected for devDependency usage.