### PR TITLE
feat: Add FCM analytics label support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,21 @@ Occasionally, errors within the Firebase Cloud Messaging (FCM) client may not be
 
 In both cases, detailed error logs are recorded in the Parse Server logs for debugging purposes.
 
+#### Analytics Label
+
+FCM analytics labels can be set with `analytics_label` in the push data. The label must match `^[a-zA-Z0-9-_.~%]{1,50}$`; valid labels are forwarded to the Firebase Admin SDK as `fcmOptions.analyticsLabel` so they appear in Firebase delivery analytics.
+
+Example payload:
+
+```js
+{
+  data: {
+    alert: 'Feature launched',
+    analytics_label: 'feature_launch-1'
+  }
+}
+```
+
 ### Expo Push Options
 
 Example options:

--- a/spec/FCM.spec.js
+++ b/spec/FCM.spec.js
@@ -378,6 +378,73 @@ describe('FCM', () => {
       expect(dataFromUser).toEqual(requestData.data);
     });
 
+    it('can generate GCM Payload with an analytics label', () => {
+      const requestData = {
+        data: {
+          alert: 'alert',
+          analytics_label: 'feature_update-1',
+        },
+      };
+
+      const pushId = 'pushId';
+      const timeStamp = 1454538822113;
+      const payload = FCM.generateFCMPayload(
+        requestData,
+        pushId,
+        timeStamp,
+        ['testToken'],
+        'android',
+      );
+
+      const fcmPayload = payload.data;
+      expect(fcmPayload.android.fcmOptions.analyticsLabel).toEqual(
+        'feature_update-1',
+      );
+
+      const dataFromUser = JSON.parse(fcmPayload.android.data.data);
+      expect(dataFromUser).toEqual({ alert: 'alert' });
+    });
+
+    it('rejects invalid analytics labels', () => {
+      const requestData = {
+        data: {
+          alert: 'alert',
+          analytics_label: 'invalid label with spaces',
+        },
+      };
+
+      expect(() => FCM.generateFCMPayload(
+        requestData,
+        'pushId',
+        1454538822113,
+        ['testToken'],
+        'android',
+      )).toThrowError(
+        Parse.Error,
+        'analytics_label must match /^[a-zA-Z0-9-_.~%]{1,50}$/',
+      );
+    });
+
+    it('rejects empty analytics labels', () => {
+      const requestData = {
+        data: {
+          alert: 'alert',
+          analytics_label: '',
+        },
+      };
+
+      expect(() => FCM.generateFCMPayload(
+        requestData,
+        'pushId',
+        1454538822113,
+        ['testToken'],
+        'android',
+      )).toThrowError(
+        Parse.Error,
+        'analytics_label must match /^[a-zA-Z0-9-_.~%]{1,50}$/',
+      );
+    });
+
     it('can generate GCM Payload with valid expiration time', () => {
       // To maintain backwards compatibility with GCM payload format
       // See corresponding test with same test label in GCM.spec.js
@@ -614,6 +681,29 @@ describe('FCM', () => {
       const fcmPayload = payload.data;
 
       expect(fcmPayload.apns.headers['apns-push-type']).toEqual('alert');
+    });
+
+    it('can generate APNS payload with an analytics label', () => {
+      const data = {
+        data: {
+          alert: 'alert',
+          analytics_label: 'ios_campaign.1',
+        },
+      };
+
+      const payload = FCM.generateFCMPayload(
+        data,
+        'pushId',
+        1454538822113,
+        ['tokenTest'],
+        'apple',
+      );
+      const fcmPayload = payload.data;
+
+      expect(fcmPayload.apns.fcmOptions.analyticsLabel).toEqual(
+        'ios_campaign.1',
+      );
+      expect(fcmPayload.apns.payload.analytics_label).toBeUndefined();
     });
 
     it('can generate APNS notification from raw data', () => {

--- a/src/FCM.js
+++ b/src/FCM.js
@@ -16,6 +16,7 @@ const apnsIntegerDataKeys = [
   'priority',
   'expiration_time',
 ];
+const analyticsLabelPattern = /^[a-zA-Z0-9-_.~%]{1,50}$/;
 
 export default function FCM(args, pushType) {
   if (typeof args !== 'object' || !args.firebaseServiceAccount) {
@@ -200,6 +201,13 @@ function _APNSToFCMPayload(requestData) {
     apnsPayload.apns.headers = headers;
   }
 
+  const analyticsLabel = getAnalyticsLabel(requestData);
+  if (analyticsLabel) {
+    apnsPayload.apns.fcmOptions = {
+      analyticsLabel,
+    };
+  }
+
   for (const key in coreData) {
     switch (key) {
     case 'aps':
@@ -261,6 +269,10 @@ function _APNSToFCMPayload(requestData) {
       break;
     case 'priority':
       break;
+    case 'analytics_label':
+      break;
+    case 'analyticsLabel':
+      break;
     default:
       apnsPayload['apns']['payload'][key] = coreData[key]; // Custom keys should be outside aps
       break;
@@ -270,6 +282,7 @@ function _APNSToFCMPayload(requestData) {
 }
 
 function _GCMToFCMPayload(requestData, pushId, timeStamp) {
+  const analyticsLabel = getAnalyticsLabel(requestData);
 
   const androidPayload = {
     android: {
@@ -277,21 +290,33 @@ function _GCMToFCMPayload(requestData, pushId, timeStamp) {
     },
   };
 
+  if (analyticsLabel) {
+    androidPayload.android.fcmOptions = {
+      analyticsLabel,
+    };
+  }
+
   if (requestData.hasOwnProperty('notification')) {
     androidPayload.android.notification = requestData.notification;
   }
 
   if (requestData.hasOwnProperty('data')) {
+    const data = { ...requestData.data };
+
     // FCM gives an error on send if we have apns keys that should have integer values
     for (const key of apnsIntegerDataKeys) {
-      if (requestData.data.hasOwnProperty(key)) {
-        delete requestData.data[key]
+      if (data.hasOwnProperty(key)) {
+        delete data[key];
       }
     }
+
+    delete data.analytics_label;
+    delete data.analyticsLabel;
+
     androidPayload.android.data = {
       push_id: pushId,
       time: new Date(timeStamp).toISOString(),
-      data: JSON.stringify(requestData.data),
+      data: JSON.stringify(data),
     }
   }
 
@@ -310,6 +335,37 @@ function _GCMToFCMPayload(requestData, pushId, timeStamp) {
   }
 
   return androidPayload;
+}
+
+function getAnalyticsLabel(requestData) {
+  const coreData = requestData.hasOwnProperty('data') ? requestData.data : requestData;
+  let analyticsLabel;
+
+  if (requestData.hasOwnProperty('analytics_label')) {
+    analyticsLabel = requestData.analytics_label;
+  } else if (requestData.hasOwnProperty('analyticsLabel')) {
+    analyticsLabel = requestData.analyticsLabel;
+  } else if (coreData.hasOwnProperty('analytics_label')) {
+    analyticsLabel = coreData.analytics_label;
+  } else if (coreData.hasOwnProperty('analyticsLabel')) {
+    analyticsLabel = coreData.analyticsLabel;
+  }
+
+  if (analyticsLabel === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof analyticsLabel !== 'string' ||
+    !analyticsLabelPattern.test(analyticsLabel)
+  ) {
+    throw new Parse.Error(
+      Parse.Error.PUSH_MISCONFIGURED,
+      'analytics_label must match /^[a-zA-Z0-9-_.~%]{1,50}$/',
+    );
+  }
+
+  return analyticsLabel;
 }
 
 /**


### PR DESCRIPTION
Fixes #377

## Summary
- Accept `analytics_label` / `analyticsLabel` in FCM push data and validate it against Firebase's analytics-label-safe character set and length.
- Forward valid labels into Firebase Admin SDK `fcmOptions.analyticsLabel` for Android and APNS-over-FCM payloads.
- Keep analytics labels out of user custom payload data and document the new option.

## Verification
- `npx eslint src/FCM.js spec/FCM.spec.js`
- `$env:TESTING='1'; npx c8 ./node_modules/.bin/jasmine` (167 specs passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics labels are now supported for FCM push notifications on Android and Apple devices with format validation.

* **Documentation**
  * Added documentation describing analytics label format requirements and example payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/parse-community/parse-server-push-adapter/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->