### PR TITLE
refactor: Bump semantic-release from 25.0.3 to 25.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint": "10.7.0",
         "jasmine": "6.2.0",
         "jasmine-spec-reporter": "7.0.0",
-        "semantic-release": "25.0.3"
+        "semantic-release": "25.0.8"
       },
       "engines": {
         "node": "20 || 22 || 24"
@@ -8046,10 +8046,11 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -15220,9 +15221,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.8.tgz",
+      "integrity": "sha512-w/iZ0bur36rKffXZYmIUmy068eoBY3Ij1DCCddx2JwWEM5Tg+eU9ld/E9qSInVvPASyyR2Ln/XGfQ9OZrMlhtw==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "10.7.0",
     "jasmine": "6.2.0",
     "jasmine-spec-reporter": "7.0.0",
-    "semantic-release": "25.0.3"
+    "semantic-release": "25.0.8"
   },
   "engines": {
     "node": "20 || 22 || 24"


### PR DESCRIPTION
Closes #581

Replacement PR for the Dependabot bump (correct commit prefix + maintainer identity).

### Changes
Bumps `semantic-release` (devDependency) from `25.0.3` to `25.0.8`.

Range `25.0.4` → `25.0.8` is all patch-level bug fixes, including several security-hardening fixes:
- `25.0.7`: fix argument injection via `repositoryUrl` in `package.json`
- `25.0.6` / `25.0.8`: ensure encoded/sensitive secrets get masked in logs
- `25.0.8`: handle potential null values in commit message and gitTags trimming
- `25.0.4` / `25.0.5`: minor code-quality / revert fixes

### Breaking Changes
None. All releases in range are patch (bug-fix) releases; no API or config changes.

### Code Changes Required
None. Manifest + lockfile only. `semantic-release` is a dev-only release-automation tool and is not part of the shipped runtime.
