### PR TITLE
refactor: Bump @eslint/js from 9.39.4 to 9.39.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "web-push": "3.6.7"
       },
       "devDependencies": {
-        "@eslint/js": "9.39.4",
+        "@eslint/js": "9.39.5",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/commit-analyzer": "13.0.1",
         "@semantic-release/git": "10.0.1",
@@ -259,9 +259,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9746,9 +9746,9 @@
       }
     },
     "@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true
     },
     "@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "web-push": "3.6.7"
   },
   "devDependencies": {
-    "@eslint/js": "9.39.4",
+    "@eslint/js": "9.39.5",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/git": "10.0.1",


### PR DESCRIPTION
Closes #580

Replacement PR for the Dependabot bump (correct commit prefix + maintainer identity).

### Changes
Bumps `@eslint/js` (devDependency) from `9.39.4` to `9.39.5`. Patch release of the ESLint core JS config package.

### Breaking Changes
None. Patch (bug-fix) release; no API or config changes.

### Code Changes Required
None. Manifest + lockfile only. `@eslint/js` is a dev-only lint dependency and is not part of the shipped runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ESLint JavaScript configuration package to version 9.39.5.
  * Refreshed dependency metadata to keep installations consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->