### PR TITLE
refactor: Bump jasmine from 6.2.0 to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "c8": "11.0.0",
         "codecov": "3.8.3",
         "eslint": "10.7.0",
-        "jasmine": "6.2.0",
+        "jasmine": "6.3.0",
         "jasmine-spec-reporter": "7.0.0",
         "semantic-release": "25.0.8"
       },
@@ -4708,24 +4708,24 @@
       }
     },
     "node_modules/jasmine": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
-      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.3.0.tgz",
+      "integrity": "sha512-u6L7yYtrtS1JALlp7f4k7Wz7o7ZKXauSKKkXc0L3qUkKrdaxYvNiMHhHp5gtTuVZZXVihXRxS7bWwDBX1wJ7EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.2.0"
+        "jasmine-core": "~6.3.0"
       },
       "bin": {
         "jasmine": "bin/jasmine.js"
       }
     },
     "node_modules/jasmine-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
-      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
       "license": "MIT"
     },
@@ -12869,20 +12869,20 @@
       }
     },
     "jasmine": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.2.0.tgz",
-      "integrity": "sha512-dvYt7bidcu0JvvSbiUnSDW7UQQiflUwDr6C+5wzoZ0J7RY9u+UcoSIzyhMPj6fnU/tC7KinJ5QrjwD2Y9p4T4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-6.3.0.tgz",
+      "integrity": "sha512-u6L7yYtrtS1JALlp7f4k7Wz7o7ZKXauSKKkXc0L3qUkKrdaxYvNiMHhHp5gtTuVZZXVihXRxS7bWwDBX1wJ7EQ==",
       "dev": true,
       "requires": {
         "@jasminejs/reporters": "^1.0.0",
         "glob": "^10.2.2 || ^11.0.3 || ^12.0.0 || ^13.0.0",
-        "jasmine-core": "~6.2.0"
+        "jasmine-core": "~6.3.0"
       }
     },
     "jasmine-core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.2.0.tgz",
-      "integrity": "sha512-b16WZG/pFEFj8qRW1ss7nDuNGYz9ji8BDGj7fJNrROauk5rj/diO3KPOuyIpcgUChdC+c0PfQ8iUk4nHE+EN4w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
+      "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true
     },
     "jasmine-spec-reporter": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "c8": "11.0.0",
     "codecov": "3.8.3",
     "eslint": "10.7.0",
-    "jasmine": "6.2.0",
+    "jasmine": "6.3.0",
     "jasmine-spec-reporter": "7.0.0",
     "semantic-release": "25.0.8"
   },


### PR DESCRIPTION
Closes #591

## Changes
Bumps the `jasmine` devDependency from 6.2.0 to 6.3.0 (replaces the Dependabot PR). Also updates the transitive `jasmine-core` to `~6.3.0` in the lockfile.

## Breaking Changes
None. This is a routine patch/minor bump of a test-only devDependency with no runtime impact.

## Code Changes
None required. Only `package.json` and `package-lock.json` are updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Jasmine testing toolkit to version 6.3.0.
  * Refreshed the associated locked dependency versions for consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->